### PR TITLE
Don't exit premature from gg_gethostbyname_real()

### DIFF
--- a/src/resolver.c
+++ b/src/resolver.c
@@ -172,19 +172,19 @@ int gg_gethostbyname_real(const char *hostname, struct in_addr **result, unsigne
 				pthread_setcancelstate(old_state, NULL);
 #endif
 
-			if (*result == NULL)
-				return -1;
+			if (*result != NULL) {
+				/* Kopiuj */
 
-			/* Kopiuj */
+				for (i = 0; he_ptr->h_addr_list[i] != NULL; i++)
+					memcpy(&((*result)[i]), he_ptr->h_addr_list[i], sizeof(struct in_addr));
 
-			for (i = 0; he_ptr->h_addr_list[i] != NULL; i++)
-				memcpy(&((*result)[i]), he_ptr->h_addr_list[i], sizeof(struct in_addr));
+				(*result)[i].s_addr = INADDR_NONE;
 
-			(*result)[i].s_addr = INADDR_NONE;
+				*count = i;
 
-			*count = i;
-
-			res = 0;
+				res = 0;
+			} else
+				res = -1;
 		}
 
 #ifdef GG_CONFIG_HAVE_PTHREAD


### PR DESCRIPTION
POSIX.1 [1] says it's undefined effect to use 'return' before pthread_cleanup_pop()

This also fix buf memleak.

[1] The effect of the use of return, break, continue, and goto to prematurely leave a code block described by a pair of pthread_cleanup_push() and pthread_cleanup_pop() functions calls is undefined.
From: http://pubs.opengroup.org/onlinepubs/009695299/functions/pthread_cleanup_pop.html
