### PR TITLE
Fix compiling of network.c on MSVC 2012.

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -29,6 +29,7 @@
 #define LIBGADU_NETWORK_H
 
 #ifdef _WIN32
+#  include <io.h>
 #  include <ws2tcpip.h>
 #  include <winsock2.h>
 #  include <stdlib.h>


### PR DESCRIPTION
Fixes #17 

Additionally, I had to add the following to my `config.h` (maybe this is handled automatically by configure).

```c
#ifdef _MSC_VER
#define snprintf _snprintf
#define strncasecmp strnicmp
#endif
```

And finally, I had to define these (I did it globally as an command line option to the compiler):
`-Dinline=__inline -D_WINSOCK_DEPRECATED_NO_WARNINGS`

Thanks for the tip on how to fix this!