### PR TITLE
spelling fix, as of lintian.debian.org

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -1281,7 +1281,7 @@ static gg_action_t gg_handle_tls_negotiation(struct gg_session *sess,
 		break;
 	}
 
-	gg_debug_session(sess, GG_DEBUG_MISC, "// gg_watch_fd() TLS negotiation succeded:\n");
+	gg_debug_session(sess, GG_DEBUG_MISC, "// gg_watch_fd() TLS negotiation succeeded:\n");
 	gg_debug_session(sess, GG_DEBUG_MISC, "//   cipher: VERS-%s:%s:%s:%s:COMP-%s\n",
 		gnutls_protocol_get_name(gnutls_protocol_get_version(GG_SESSION_GNUTLS(sess))),
 		gnutls_cipher_get_name(gnutls_cipher_get(GG_SESSION_GNUTLS(sess))),
@@ -1379,7 +1379,7 @@ static gg_action_t gg_handle_tls_negotiation(struct gg_session *sess,
 	}
 
 	gg_debug_session(sess, GG_DEBUG_MISC, "// gg_watch_fd() TLS negotiation"
-		" succeded:\n//   cipher: %s\n",
+		" succeeded:\n//   cipher: %s\n",
 		SSL_get_cipher_name(GG_SESSION_OPENSSL(sess)));
 
 	peer = SSL_get_peer_certificate(GG_SESSION_OPENSSL(sess));

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -363,7 +363,7 @@ static int gg_session_handle_welcome(struct gg_session *gs, uint32_t type,
 static int gg_session_handle_login_ok(struct gg_session *gs, uint32_t type,
 	const char *ptr, size_t len, struct gg_event *ge)
 {
-	gg_debug_session(gs, GG_DEBUG_MISC, "// gg_watch_fd() login succeded\n");
+	gg_debug_session(gs, GG_DEBUG_MISC, "// gg_watch_fd() login succeeded\n");
 	ge->type = GG_EVENT_CONN_SUCCESS;
 	gs->state = GG_STATE_CONNECTED;
 	gs->check = GG_CHECK_READ;


### PR DESCRIPTION
spelling fix, as of 
https://lintian.debian.org/full/porridge@debian.org.html#libgadu_1_x3a1.12.1-2

the other mentioned one, seems to be a non-english string, therefore its a false-positive.
usr/lib/i386-linux-gnu/libgadu.so.3.13.0 nam name