### PR TITLE
CI na Travisie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Makefile
 Makefile.in
+INSTALL
 *.m4
 *.o
 *.la

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ dist: trusty
 sudo: false
 
 env:
-  - COMPILER=clang-3.5
-  - COMPILER=clang-4.0
   - COMPILER=gcc-6
-  - COMPILER=gcc-5
+  - COMPILER=gcc-6 FLAGS=--without-protobuf
   - COMPILER=gcc-4.9
-
+  - COMPILER=clang-4.0
+  
 addons:
   apt:
     sources:
@@ -16,14 +15,23 @@ addons:
     - llvm-toolchain-trusty-4.0
     packages:
     - gcc-6
-    - gcc-5
-    - clang-3.5
+    - gcc-4.9
     - clang-4.0
-    - protobuf-c-compiler
-
+    - doxygen
+    
 script:
+  - export PATH="$HOME/lib/protobuf-c/bin:$PATH"
+  - export PKG_CONFIG_PATH=$HOME/lib/protobuf-c/lib/pkgconfig:$HOME/lib/protobuf/lib/pkgconfig
+  - wget https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-3.2.0.tar.gz
+  - tar -xzvf protobuf-cpp-3.2.0.tar.gz
+  - cd protobuf-3.2.0 && ./configure --prefix=$HOME/lib/protobuf && make -j4 && make install
+  - cd -
+  - wget https://github.com/protobuf-c/protobuf-c/releases/download/v1.2.1/protobuf-c-1.2.1.tar.gz
+  - tar -xzvf protobuf-c-1.2.1.tar.gz
+  - cd protobuf-c-1.2.1 &&  ./configure --prefix=$HOME/lib/protobuf-c && make -j4 && make install
+  - cd -
   - export CC=$COMPILER
-  - ./autogen.sh && make -j 4
+  - ./autogen.sh $FLAGS && make -j4
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - COMPILER=clang-4.0
   - COMPILER=gcc-6
   - COMPILER=gcc-5
-  - COMPILER=gcc
+  - COMPILER=gcc-4.9
 
 addons:
   apt:
@@ -17,7 +17,6 @@ addons:
     packages:
     - gcc-6
     - gcc-5
-    - gcc-4
     - clang-3.5
     - clang-4.0
     - protobuf-c-compiler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: c
+dist: trusty
+sudo: false
+
+env:
+  - COMPILER=clang++-3.5
+  - COMPILER=clang++-4.0
+  - COMPILER=gcc-6
+  - COMPILER=gcc-5
+  - COMPILER=gcc
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-trusty-4.0
+    packages:
+    - g++-6
+    - g++-5
+    - g++-4
+    - clang-3.5
+    - clang-4.0
+    - protobuf-c-compiler
+
+script:
+  - export CC=$COMPILER
+  - libtoolize && aclocal && autoheader && autoconf && automake --add-missing && ./configure && make -j 4
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 sudo: false
 
 env:
-  - COMPILER=clang++-3.5
-  - COMPILER=clang++-4.0
+  - COMPILER=clang-3.5
+  - COMPILER=clang-4.0
   - COMPILER=gcc-6
   - COMPILER=gcc-5
   - COMPILER=gcc
@@ -15,16 +15,16 @@ addons:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-trusty-4.0
     packages:
-    - g++-6
-    - g++-5
-    - g++-4
+    - gcc-6
+    - gcc-5
+    - gcc-4
     - clang-3.5
     - clang-4.0
     - protobuf-c-compiler
 
 script:
   - export CC=$COMPILER
-  - libtoolize && aclocal && autoheader && autoconf && automake --add-missing && ./configure && make -j 4
+  - ./autogen.sh && make -j 4
 
 notifications:
   email: false

--- a/configure.ac
+++ b/configure.ac
@@ -273,6 +273,7 @@ if test "x$with_protobuf" != "xno"; then
 			have_protobuf_c=no
 		else
 			LIBS_PRIVATE="$LIBS_PRIVATE $PROTOBUF_C_LIBS"
+			CFLAGS="$CFLAGS $PROTOBUF_C_CFLAGS"
 			AC_DEFINE([GG_CONFIG_HAVE_PROTOBUF_C], [], [Defined if libgadu was compiled and linked with system provided libprotobuf-c.])
 			have_protobuf_c=yes
 		fi


### PR DESCRIPTION
Wiem, że to może być przerost formy nad treścią, ale ogarniałem travisa i postanowiłem zrobić coś pożytecznego:
 - build na gcc4, gcc6 i clang4
 - build z opcją --without-protobuf
 - drobna zmiana w configure.am, żeby umożliwić budowanie z bibliotek w niestandardowych lokalizacjach

Jeśli są jakieś opcje/konfiguracja, kóre warto zbudować daj proszę znać.
Mogę również dodać testy, ale niestety nie znalazłem opisu jak je uruchomić.
Warto też dodać standardową travisową ikonkę do readme.md, ale raczej dobrze, żeby wskazywała na projekt właściciela repo.

Output z builda wygląda mniej więcej tak:
https://travis-ci.org/vanklompf/libgadu

Jak się nie nadaje/nie potrzeba to bez obaw, nie jestem z tymi zmianami związany emocjonalnie ;-)
